### PR TITLE
Fix update image logic and form enctype

### DIFF
--- a/components/admin/forms/UpdateBannerForm.tsx
+++ b/components/admin/forms/UpdateBannerForm.tsx
@@ -32,8 +32,7 @@ const UpdateBannerForm = ({ banner }: { banner: BannerType }) => {
     pending,
     errors: fieldErrors,
   } = useFormSubmit(
-    (formData) =>
-      updateBannerAction(banner.id, formData, urlImage || banner.image),
+    (formData) => updateBannerAction(banner.id, formData, urlImage),
     {
       // onSuccessRedirect: '/admin/banners',
       onSuccessMessage: 'Category updated successfully',
@@ -57,6 +56,7 @@ const UpdateBannerForm = ({ banner }: { banner: BannerType }) => {
   return (
     <form
       action={updateBanner}
+      encType='multipart/form-data'
       className='w-full flex flex-col gap-4 justify-center space-y-4 mt-3 md:mt-5'
     >
       <div className='flex gap-4 items-center'>

--- a/components/admin/forms/UpdateCategoryForm.tsx
+++ b/components/admin/forms/UpdateCategoryForm.tsx
@@ -31,8 +31,7 @@ const UpdateCategoryForm = ({ category }: { category: TypeCategory }) => {
     pending,
     errors: fieldErrors,
   } = useFormSubmit(
-    (formData) =>
-      updateCategoryAction(category.id, formData, urlImage || category.image),
+    (formData) => updateCategoryAction(category.id, formData, urlImage),
     {
       onSuccessRedirect: '/admin/categories',
       onSuccessMessage: 'Category updated successfully',
@@ -53,6 +52,7 @@ const UpdateCategoryForm = ({ category }: { category: TypeCategory }) => {
   return (
     <form
       action={updateCategory}
+      encType='multipart/form-data'
       className='w-full flex flex-col gap-4 justify-center space-y-4 mt-3 md:mt-5'
     >
       <div className='flex gap-4 items-center'>

--- a/components/admin/forms/UpdateForm.tsx
+++ b/components/admin/forms/UpdateForm.tsx
@@ -35,8 +35,7 @@ const UpdateForm = ({ product }: { product: ProductType }) => {
     pending,
     errors: fieldErrors,
   } = useFormSubmit(
-    (formData) =>
-      updateProductAction(product.id, formData, urlImage || product.imageUrl),
+    (formData) => updateProductAction(product.id, formData, urlImage),
     {
       onSuccessRedirect: '/admin/products',
       onSuccessMessage: 'Product edit successfully',
@@ -57,6 +56,7 @@ const UpdateForm = ({ product }: { product: ProductType }) => {
   return (
     <form
       action={updateProduct}
+      encType='multipart/form-data'
       className='w-full flex flex-col gap-4 justify-center space-y-4 mt-3 md:mt-5'
     >
       <div className='flex gap-4 items-center'>

--- a/lib/actions/media.action.ts
+++ b/lib/actions/media.action.ts
@@ -203,15 +203,16 @@ export const updateBannerAction = async (
         results: null,
       }
     }
-    // Image processing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let imageResponse: any = null
-
-    if (!urlImage) {
+    // Determine final image url
+    let finalImage = existingBanner.image
+    if (urlImage) {
+      finalImage = urlImage
+    } else if (image) {
       const arrayBuffer = await image.arrayBuffer()
       const buffer = new Uint8Array(arrayBuffer)
 
-      imageResponse = await new Promise((resolve, reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const imageResponse: any = await new Promise((resolve, reject) => {
         cloudinary.uploader
           .upload_stream(
             {
@@ -229,14 +230,12 @@ export const updateBannerAction = async (
           )
           .end(buffer)
       })
+      finalImage = imageResponse.secure_url
     }
-
-    // If the image is not provided, use the existing image URL
-    const img = imageResponse?.secure_url ? imageResponse.secure_url : urlImage
 
     await Banner.findByIdAndUpdate(id, {
       title,
-      image: img,
+      image: finalImage,
       description,
       alt,
       buttonText,

--- a/lib/actions/product.action.ts
+++ b/lib/actions/product.action.ts
@@ -343,15 +343,16 @@ export const updateProductAction = async (
       }
     }
 
-    // Image processing
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let imageResponse: any = null
-
-    if (!urlImage) {
+    // Determine final image
+    let finalImage = existingProduct.imageUrl
+    if (urlImage) {
+      finalImage = urlImage
+    } else if (image) {
       const arrayBuffer = await image.arrayBuffer()
       const buffer = new Uint8Array(arrayBuffer)
 
-      imageResponse = await new Promise((resolve, reject) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const imageResponse: any = await new Promise((resolve, reject) => {
         cloudinary.uploader
           .upload_stream(
             {
@@ -369,14 +370,12 @@ export const updateProductAction = async (
           )
           .end(buffer)
       })
+      finalImage = imageResponse.secure_url
     }
-
-    // If the image is not provided, use the existing image URL
-    const img = imageResponse?.secure_url ? imageResponse.secure_url : urlImage
 
     // store to mongodb
     await Product.findByIdAndUpdate(id, {
-      imageUrl: img,
+      imageUrl: finalImage,
       name,
       price: parseFloat(price),
       description,


### PR DESCRIPTION
## Summary
- ensure update banner/category/product forms send multipart data
- update server actions to reuse existing image when urlImage not provided

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e977f6d18832581a930fb7d64f233