### PR TITLE
Update formatDate to use UTC

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -23,11 +23,10 @@ export const truncateString = (str: string, maxLength: number) => {
 }
 
 export const formatDate = (dateString: string) => {
-  const options: Intl.DateTimeFormatOptions = {
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: 'UTC',
     year: 'numeric',
     month: '2-digit',
     day: '2-digit',
-  }
-  const date = new Date(dateString)
-  return date.toLocaleDateString('en-US', options)
+  }).format(new Date(dateString))
 }


### PR DESCRIPTION
## Summary
- switch date formatting to `Intl.DateTimeFormat` with `timeZone: 'UTC'`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9ba3219c8325a00fc8e8c688b88f