### PR TITLE
Fix admin typos

### DIFF
--- a/app/(admin)/admin/banner/update/[id]/page.tsx
+++ b/app/(admin)/admin/banner/update/[id]/page.tsx
@@ -19,7 +19,7 @@ const UpdatePage = async ({ params }: Props) => {
   return (
     <main className='px-4 md:px-8 bg-gray-50 pb-8'>
       <div className='w-full'>
-        <h2 className='font-semibold pt-8 text-xl md:text-2xl'>Edit Cetgory</h2>
+        <h2 className='font-semibold pt-8 text-xl md:text-2xl'>Edit Category</h2>
         <Button asChild className='rounded-none cursor-pointer mt-5'>
           <Link href='/admin/banners'>Back to Banners</Link>
         </Button>

--- a/app/(admin)/admin/category/update/[id]/page.tsx
+++ b/app/(admin)/admin/category/update/[id]/page.tsx
@@ -19,7 +19,7 @@ const UpdatePage = async ({ params }: Props) => {
   return (
     <main className='px-4 md:px-8 bg-gray-50 pb-8'>
       <div className='w-full'>
-        <h2 className='font-semibold pt-8 text-xl md:text-2xl'>Edit Cetgory</h2>
+        <h2 className='font-semibold pt-8 text-xl md:text-2xl'>Edit Category</h2>
         <Button asChild className='rounded-none cursor-pointer mt-5'>
           <Link href='/admin/categories'>Back to Categories</Link>
         </Button>

--- a/components/admin/forms/UpdateCategoryForm.tsx
+++ b/components/admin/forms/UpdateCategoryForm.tsx
@@ -145,7 +145,7 @@ const UpdateCategoryForm = ({ category }: { category: TypeCategory }) => {
         type='submit'
         className='cursor-pointer [disabled]:opacity-50'
       >
-        {pending ? 'Updateting...' : 'Update Category'}
+        {pending ? 'Updating...' : 'Update Category'}
       </Button>
     </form>
   )


### PR DESCRIPTION
## Summary
- correct heading typo on edit category and banner pages
- fix updating button text in UpdateCategoryForm

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e9d7f97d08325ae29820332efab71