### PR TITLE
Remove encType props from update forms

### DIFF
--- a/components/admin/forms/UpdateBannerForm.tsx
+++ b/components/admin/forms/UpdateBannerForm.tsx
@@ -56,7 +56,6 @@ const UpdateBannerForm = ({ banner }: { banner: BannerType }) => {
   return (
     <form
       action={updateBanner}
-      encType='multipart/form-data'
       className='w-full flex flex-col gap-4 justify-center space-y-4 mt-3 md:mt-5'
     >
       <div className='flex gap-4 items-center'>

--- a/components/admin/forms/UpdateCategoryForm.tsx
+++ b/components/admin/forms/UpdateCategoryForm.tsx
@@ -52,7 +52,6 @@ const UpdateCategoryForm = ({ category }: { category: TypeCategory }) => {
   return (
     <form
       action={updateCategory}
-      encType='multipart/form-data'
       className='w-full flex flex-col gap-4 justify-center space-y-4 mt-3 md:mt-5'
     >
       <div className='flex gap-4 items-center'>

--- a/components/admin/forms/UpdateForm.tsx
+++ b/components/admin/forms/UpdateForm.tsx
@@ -56,7 +56,6 @@ const UpdateForm = ({ product }: { product: ProductType }) => {
   return (
     <form
       action={updateProduct}
-      encType='multipart/form-data'
       className='w-full flex flex-col gap-4 justify-center space-y-4 mt-3 md:mt-5'
     >
       <div className='flex gap-4 items-center'>


### PR DESCRIPTION
## Summary
- remove the unused `encType` attribute from admin update forms

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea0935ebc8325a5c4923c615c0e3c